### PR TITLE
✨feat : ToastAlert 추가 

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css';
 import ClientProvider from '@/components/common/provider/provider';
 import RootTemplate from '@/components/common/layoutTemplate/RootTemplate';
 import Script from 'next/script';
+import ToastAlertComponent from '@/components/common/toastAlert';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -28,7 +29,10 @@ export default function RootLayout({
       </head>
       <body className={inter.className}>
         <ClientProvider>
-          <RootTemplate>{children}</RootTemplate>
+          <RootTemplate>
+            {children}
+            <ToastAlertComponent />
+          </RootTemplate>
         </ClientProvider>
       </body>
     </html>

--- a/atoms/toastAlert/alert.ts
+++ b/atoms/toastAlert/alert.ts
@@ -1,0 +1,11 @@
+import { atom } from 'recoil';
+
+export const AlertOpenState = atom<boolean>({
+  key: 'AlertOpenState',
+  default: false,
+});
+
+export const AlertMessageState = atom<string>({
+  key: 'AlertMessageState',
+  default: '',
+});

--- a/components/common/toastAlert/index.tsx
+++ b/components/common/toastAlert/index.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Alert } from '@material-tailwind/react';
 import { motion } from 'framer-motion';
 import { useRecoilState } from 'recoil';
@@ -13,11 +13,22 @@ const ToastAlertComponent = () => {
     setIsOpen(false);
   };
 
+  useEffect(() => {
+    if (isOpen) {
+      const floating = setTimeout(() => {
+        setIsOpen(false);
+      }, 4000);
+      return () => {
+        clearTimeout(floating);
+      };
+    }
+  }, [isOpen, setIsOpen]);
+
   return (
     <div className="flex items-center fixed bottom-0  w-full  mb-28  z-[2000]">
       <Alert
         open={isOpen}
-        className="relative flex items-center max-w-[440px] w-full h-[56px] py-2  rounded-[4px] mx-5 bg-gray-900 text-p2 text-white font-pretend"
+        className="relative flex items-center max-w-[440px] w-full h-[56px] py-2  rounded-[4px] mx-5 bg-gray-900 text-p2 text-white font-pretend shadow-xl"
         onClose={alertCloseHandler}
         animate={{
           mount: { y: 0 },

--- a/components/common/toastAlert/index.tsx
+++ b/components/common/toastAlert/index.tsx
@@ -1,0 +1,40 @@
+'use client';
+import React from 'react';
+import { Alert } from '@material-tailwind/react';
+import { motion } from 'framer-motion';
+import { useRecoilState } from 'recoil';
+import { AlertMessageState, AlertOpenState } from '@/atoms/toastAlert/alert';
+
+const ToastAlertComponent = () => {
+  const [alertMessage] = useRecoilState<string>(AlertMessageState);
+  const [isOpen, setIsOpen] = useRecoilState(AlertOpenState);
+
+  const alertCloseHandler = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="flex items-center fixed bottom-0  w-full  mb-28  z-[2000]">
+      <Alert
+        open={isOpen}
+        className="relative flex items-center max-w-[440px] w-full h-[56px] py-2  rounded-[4px] mx-5 bg-gray-900 text-p2 text-white font-pretend"
+        onClose={alertCloseHandler}
+        animate={{
+          mount: { y: 0 },
+          unmount: { y: 100 },
+        }}
+      >
+        <motion.div
+          className="absolute top-0 left-0 h-[4px] bg-white rounded-[4px]"
+          style={{ width: isOpen ? '100%' : '0%' }}
+          animate={{ width: isOpen ? '0%' : '100%' }}
+          transition={{ duration: 3.5, ease: 'easeInOut' }}
+        />
+
+        <div className="flex justify-center mr-0">{alertMessage}</div>
+      </Alert>
+    </div>
+  );
+};
+
+export default ToastAlertComponent;

--- a/components/common/toastAlert/index.tsx
+++ b/components/common/toastAlert/index.tsx
@@ -25,7 +25,7 @@ const ToastAlertComponent = () => {
         }}
       >
         <motion.div
-          className="absolute top-0 left-0 h-[4px] bg-white rounded-[4px]"
+          className="absolute top-0 left-0 h-[4px] bg-gray-200 rounded-[4px]"
           style={{ width: isOpen ? '100%' : '0%' }}
           animate={{ width: isOpen ? '0%' : '100%' }}
           transition={{ duration: 3.5, ease: 'easeInOut' }}

--- a/hooks/useToastAlert.ts
+++ b/hooks/useToastAlert.ts
@@ -1,0 +1,34 @@
+'use client';
+import { AlertMessageState, AlertOpenState } from '@/atoms/toastAlert/alert';
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+
+/**
+ * @function useToastAlert -
+ * @param Message -
+ * @returns { isLoading, btnHandler } -
+ * @example const { isOpen, alertMessage, alertOpenHandler, alertCloseHandler } = useToastAlert('작업을 완료했습니다.');
+ */
+
+export const useToastAlert = (message: string) => {
+  const [isOpen, setIsOpen] = useRecoilState(AlertOpenState);
+  const [, setAlertMessage] = useRecoilState<string>(AlertMessageState);
+
+  const alertOpenHandler = () => {
+    setAlertMessage(message);
+    setIsOpen(true);
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      const floating = setTimeout(() => {
+        setIsOpen(false);
+      }, 4000);
+      return () => {
+        clearTimeout(floating);
+      };
+    }
+  }, [isOpen, setIsOpen]);
+
+  return { alertOpenHandler };
+};

--- a/hooks/useToastAlert.ts
+++ b/hooks/useToastAlert.ts
@@ -1,6 +1,6 @@
 'use client';
 import { AlertMessageState, AlertOpenState } from '@/atoms/toastAlert/alert';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 
 /**
  * @function useToastAlert - Alert 메세지를 지정하고, 알럿을 트리거할 버튼을 `alertOpenHandler`을 통해 지정할 수 있습니다.
@@ -10,8 +10,8 @@ import { useRecoilState } from 'recoil';
  */
 
 export const useToastAlert = (message: string) => {
-  const [, setIsOpen] = useRecoilState(AlertOpenState);
-  const [, setAlertMessage] = useRecoilState<string>(AlertMessageState);
+  const setIsOpen = useSetRecoilState(AlertOpenState);
+  const setAlertMessage = useSetRecoilState<string>(AlertMessageState);
 
   const alertOpenHandler = () => {
     setAlertMessage(message);

--- a/hooks/useToastAlert.ts
+++ b/hooks/useToastAlert.ts
@@ -1,34 +1,22 @@
 'use client';
 import { AlertMessageState, AlertOpenState } from '@/atoms/toastAlert/alert';
-import { useEffect } from 'react';
 import { useRecoilState } from 'recoil';
 
 /**
- * @function useToastAlert -
- * @param Message -
- * @returns { isLoading, btnHandler } -
- * @example const { isOpen, alertMessage, alertOpenHandler, alertCloseHandler } = useToastAlert('작업을 완료했습니다.');
+ * @function useToastAlert - Alert 메세지를 지정하고, 알럿을 트리거할 버튼을 `alertOpenHandler`을 통해 지정할 수 있습니다.
+ * @param Message - Alert에 띄울 메세지를 입력해주시면 됩니다.
+ * @returns  alertOpenHandler - 알럿을 띄우고, 메세지를 지정하는 핸들러 함수입니다.
+ * @example const { alertOpenHandler } = useToastAlert('작업을 완료했습니다.');
  */
 
 export const useToastAlert = (message: string) => {
-  const [isOpen, setIsOpen] = useRecoilState(AlertOpenState);
+  const [, setIsOpen] = useRecoilState(AlertOpenState);
   const [, setAlertMessage] = useRecoilState<string>(AlertMessageState);
 
   const alertOpenHandler = () => {
     setAlertMessage(message);
     setIsOpen(true);
   };
-
-  useEffect(() => {
-    if (isOpen) {
-      const floating = setTimeout(() => {
-        setIsOpen(false);
-      }, 4000);
-      return () => {
-        clearTimeout(floating);
-      };
-    }
-  }, [isOpen, setIsOpen]);
 
   return { alertOpenHandler };
 };


### PR DESCRIPTION
close #116 

# 안녕하세요?
![image](https://github.com/catchroom/FE_CatchRoom/assets/122848687/e18399e8-2527-4224-b6ed-97bd187aa152)


# 공동컴포넌트(?) Alert 추가 완료했습니다.

### 🛠 몇가지 잡다한 기능 추가
![36](https://github.com/catchroom/FE_CatchRoom/assets/122848687/ad23be69-cca4-40b8-b1a3-4b7d77b5e9c2)

디자인 시안에는 그냥 알럿만 뜨는 식으로 되어있던데,

사용자 입장에서 직접 알럿도 지우고, 얼마나 오래 떠있는지 

눈으로 확인하면 편리할 것 같아서 한번 추가해봤습니다.

<br/><br/>

## 다른 페이지로 이동해도 거뜬한 Alert
![37](https://github.com/catchroom/FE_CatchRoom/assets/122848687/4d072608-b8b5-44e0-b83f-ea63ed3d5f14)

추가로, 다른 페이지로 이동시에 컴포넌트들이 언마운트되어

알럿이 사라지는 현상을 고려해서 따로 layout 단위로 컴포넌트를 미리 빼뒀습니다.

<br/><br/>

# 🤔 그래서 어떻게 쓰는건데??
### 사용방법도 간단하게 해뒀습니다
~~인체공학적~~

```jsx
  const { alertOpenHandler } =
       useToastAlert('여기에 알럿에 띄울 메세지를 입력');

return (
       <>
          <button onClick={alertOpenHandler}>
            저는 버튼이에요
          </button>
        </>
  );
 
```

네. 위의 코드가 전부입니다.

따로 컴포넌트 불러 올 필요없이 커스텀 훅 `useToastAlert`만 이용해서

여러분은 그냥 간단하게 사용만 하시면 됩니당 ㅎㅎ