### PR TITLE
✨ feat : 상품 상세 바텀시트 구현

### DIFF
--- a/atoms/commons/outerBottomSheetsControl.ts
+++ b/atoms/commons/outerBottomSheetsControl.ts
@@ -19,3 +19,8 @@ export const outerDatePickerBottomSheetsControl = atom<boolean>({
   key: 'outerDatePickerBottomSheetsControl',
   default: false,
 });
+
+export const outerMoreBottomSheetsControl = atom<boolean>({
+  key: 'outerMoreBottomSheetsControl',
+  default: false,
+});

--- a/components/common/bottomSheetsWithOutCloseBtn/index.tsx
+++ b/components/common/bottomSheetsWithOutCloseBtn/index.tsx
@@ -11,9 +11,11 @@ import { useRecoilState } from 'recoil';
 import {
   outerBottomSheetsControl,
   outerDatePickerBottomSheetsControl,
+  outerMoreBottomSheetsControl,
 } from '@/atoms/commons/outerBottomSheetsControl';
 import DropdownButton from '../sheetsButtons/dropdownButton';
 import CalendarButton from '../sheetsButtons/calendarButton';
+import MoreButton from '../sheetsButtons/moreButton';
 
 /**
  * @function BottomSheetsWithoutCloseBtn - bottom sheets component입니다. 모달 대체용으로 사용합니다.
@@ -34,16 +36,17 @@ const BottomSheetsWithoutCloseBtn = ({
   outerControlAtom = 'default',
 }: {
   children: ReactNode;
-  title: string;
-  buttonSelect?: 'dropdown' | 'calendar';
+  title?: string;
+  buttonSelect?: 'dropdown' | 'calendar' | 'more';
   outerControl?: boolean;
-  outerControlAtom?: 'default' | 'datePicker';
+  outerControlAtom?: 'default' | 'datePicker' | 'more';
 }) => {
   const [open, setOpen] = useState(false);
 
   const outerControlState = {
     default: outerBottomSheetsControl,
     datePicker: outerDatePickerBottomSheetsControl,
+    more: outerMoreBottomSheetsControl,
   };
 
   const [outerOpen, setOuterOpen] = useRecoilState(
@@ -75,8 +78,9 @@ const BottomSheetsWithoutCloseBtn = ({
   };
 
   const ButtonsComponentsObjects: Record<string, React.JSX.Element> = {
-    dropdown: <DropdownButton name={title} fn={modalOpen} />,
-    calendar: <CalendarButton name={title} fn={modalOpen} />,
+    dropdown: <DropdownButton name={title as string} fn={modalOpen} />,
+    calendar: <CalendarButton name={title as string} fn={modalOpen} />,
+    more: <MoreButton fn={modalOpen} />,
   };
 
   return (

--- a/components/common/modal/index.tsx
+++ b/components/common/modal/index.tsx
@@ -33,7 +33,7 @@ const Modal = ({
 }) => {
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center z-[999]">
-      <div className="bg-white rounded-lg shadow-lg flex flex-col items-center z-[1000]">
+      <div className="bg-white rounded-lg shadow-lg flex flex-col items-center z-[1000] max-w-[240px] w-full text-center">
         <div className="flex flex-col p-6 gap-1 ">
           <div className="font-bold text-p1 w-[200px] flex justify-center text-center whitespace-pre-wrap">
             {title}

--- a/components/common/sheetsButtons/moreButton/index.tsx
+++ b/components/common/sheetsButtons/moreButton/index.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import MoreIcon from '@/public/svgComponent/moreIcon';
+import React, { MouseEventHandler } from 'react';
+
+const MoreButton = ({ fn }: { fn: MouseEventHandler<HTMLButtonElement> }) => {
+  return (
+    <button onClick={fn}>
+      <MoreIcon />
+    </button>
+  );
+};
+
+export default MoreButton;

--- a/components/roomInfo/header/index.tsx
+++ b/components/roomInfo/header/index.tsx
@@ -1,14 +1,23 @@
 'use client';
 // import { inView } from 'framer-motion';
-import React from 'react';
+import React, { useState } from 'react';
 import LeftButton from './leftButton';
 import RightButton from './rightButton';
 import { Button } from '@material-tailwind/react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { viewerTestButton } from '@/atoms/roomInfo/headerTitle';
-import MoreIcon from '@/public/svgComponent/moreIcon';
+import BottomSheetsWithoutCloseBtn from '@/components/common/bottomSheetsWithOutCloseBtn';
+import { outerMoreBottomSheetsControl } from '@/atoms/commons/outerBottomSheetsControl';
+import Modal from '@/components/common/modal';
+import { useRouter } from 'next/navigation';
 
 const HeaderComponent = () => {
+  const setMoreBottomSheetOpen = useSetRecoilState(
+    outerMoreBottomSheetsControl,
+  );
+
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
   // ----------- 헤더부분에 스크롤에 따라 숙소이름 뜨게하려는 중...
 
   // const [scroll, setScroll] = useState<boolean>(false);
@@ -44,29 +53,77 @@ const HeaderComponent = () => {
   };
   // ---------------------------------------------------------
 
-  return (
-    <div className="fixed top-0 flex justify-between w-full max-w-[480px] bg-bg p-4 z-20">
-      <LeftButton />
-      {/* 스크롤에 따라 숙소이름 뜨게 하려는 용도.. */}
-      {/* <p className="text-h5 font-extrabold">123</p> */}
+  const handleEditBtnClick = () => {
+    setMoreBottomSheetOpen(false);
+    //판매할 id 추가해야함
+    router.push('/sale');
+  };
 
-      {/* 판매자 및 구매자 화면 전환용 (테스트용이고, 추후 삭제 예정입니다!)*/}
-      <Button
-        placeholder="Button"
-        type="button"
-        onClick={viewerTestHandler}
-        className={`flex items-center  font-pretend h-[28px] rounded-[4px] text-[10px] font-semibold shadow-none bg-main text-white p-3`}
-      >
-        {viewerState ? `판매자 화면` : `구매자 화면`}
-      </Button>
-      {viewerState ? (
-        <button className="flex items-center justify-center w-[1.75rem] h-[1.75rem] ">
-          <MoreIcon />
-        </button>
-      ) : (
-        <RightButton />
+  const handleDeleteBtnClick = () => {
+    setMoreBottomSheetOpen(false);
+    handleModalOpen();
+  };
+
+  const onConfirm = () => {
+    handleModalOpen();
+    router.push('/mypage/dashboard/sales');
+  };
+
+  const onCancel = () => {
+    handleModalOpen();
+  };
+
+  const handleModalOpen = () => {
+    setOpen((prev) => !prev);
+  };
+
+  return (
+    <>
+      <div className="fixed top-0 flex justify-between w-full max-w-[480px] bg-bg p-4 z-20">
+        <LeftButton />
+        {/* 스크롤에 따라 숙소이름 뜨게 하려는 용도.. */}
+        {/* <p className="text-h5 font-extrabold">123</p> */}
+
+        {/* 판매자 및 구매자 화면 전환용 (테스트용이고, 추후 삭제 예정입니다!)*/}
+        <Button
+          placeholder="Button"
+          type="button"
+          onClick={viewerTestHandler}
+          className={`flex items-center  font-pretend h-[28px] rounded-[4px] text-[10px] font-semibold shadow-none bg-main text-white p-3`}
+        >
+          {viewerState ? `판매자 화면` : `구매자 화면`}
+        </Button>
+        {viewerState ? (
+          <button className="flex items-center justify-center w-[1.75rem] h-[1.75rem] ">
+            {/* <MoreIcon /> */}
+            <BottomSheetsWithoutCloseBtn
+              buttonSelect="more"
+              outerControlAtom="more"
+              outerControl={true}
+            >
+              <div className="flex flex-col gap-7 w-full py-3 text-t1 font-bold">
+                <div onClick={handleEditBtnClick}>수정하기</div>
+                <div onClick={handleDeleteBtnClick}>삭제하기</div>
+              </div>
+            </BottomSheetsWithoutCloseBtn>
+          </button>
+        ) : (
+          <RightButton />
+        )}
+      </div>
+
+      {open && (
+        <Modal
+          title="게시물 삭제"
+          content="마켓에서 게시글이 삭제됩니다. 삭제된 매물은 &#13;&#10;내역에서도 확인하실 수 &#13;&#10; 없습니다."
+          showConfirmButton={true}
+          showCancelButton={true}
+          confirmString="삭제하기"
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+        />
       )}
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## ✨ 이슈번호
Close #171 

## ☎ 추가 전달 사항
![image](https://github.com/catchroom/FE_CatchRoom/assets/65649035/4c363ccb-6715-4196-9092-30347416f918)
![image](https://github.com/catchroom/FE_CatchRoom/assets/65649035/91b4ed58-eabe-435e-b4e9-2d516ac915cb)

수정, 삭제 가능한 바텀시트 구현했습니다
삭제 버튼 누르면 모달이 뜨고 판매 내역 페이지로 이동합니다.

+이후 판매자, 구매자 나눠지는 API나오면
수정 버튼을 클릭하면 판매 페이지로 이동하는데 이때 판메 상품 product id 를 param으로 넘기는 로직 추가되어야 합니다.
