### PR TITLE
♻ refactor : 상품 상세페이지 숙소 정보 추가 및 공동 컴포넌트 날짜 props 세분화 

### DIFF
--- a/components/catchItems/items/index.tsx
+++ b/components/catchItems/items/index.tsx
@@ -40,7 +40,7 @@ const ItemsComponent = () => {
 
   return (
     <div className=" overflow-y-hidden">
-      <div className="w-full flex flex-col mt-56 gap-12 p-6 pt-2">
+      <div className="w-full flex flex-col mt-56 gap-[2rem] p-6 pt-2">
         {data &&
           data.list.map((data: DeadLineItem) => {
             return (
@@ -50,7 +50,8 @@ const ItemsComponent = () => {
                 image={data.image}
                 accommodationName={data.accommodationName}
                 roomName={data.roomName}
-                resDate={data.checkIn + ' - ' + data.checkOut}
+                checkIn={data.checkIn}
+                checkOut={data.checkOut}
                 catchType={data.catchType}
                 originalPrice={data.originalPrice}
                 discountRate={data.discountRate}

--- a/components/common/calendar/index.tsx
+++ b/components/common/calendar/index.tsx
@@ -59,8 +59,8 @@ const CalendarComponent = ({
     to: new Date(2099, 12, 31),
   };
 
-  const leftFooterStyle = 'text-h3 font-semibold mr-3 break-keep';
-  const rightFooterStyle = 'text-h3 font-semibold ml-3 break-keep';
+  const leftFooterStyle = 'text-h3 font-medium mr-3 break-keep';
+  const rightFooterStyle = 'text-h3 font-medium ml-3 break-keep';
 
   let footer = (
     <>
@@ -131,7 +131,7 @@ const CalendarComponent = ({
                 </div>
               ) : (
                 <div className="flex flex-col mt-5">
-                  <span className="mb-3">입실 희망 날짜</span>
+                  <span className="mb-3 text-text-sub">입실 희망 날짜</span>
                   <div className="flex items-center">{footer}</div>
                 </div>
               )

--- a/components/common/catchComponent/index.tsx
+++ b/components/common/catchComponent/index.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import XSymbolIcon from '@/public/svgComponent/xSymbol';
 import CalendarIcon from '@/public/svgComponent/calendar';
 import HeartButton from '../heartButton';
+import { formatDateWithDay } from '@/utils/get-dot-date';
 
 /**
  * 상품들을 조회할 수 있는 컴포넌트입니다.
@@ -34,7 +35,8 @@ const CatchSpecialComponent = ({
   image = '/sample/room3.png',
   accommodationName,
   roomName,
-  resDate,
+  checkIn,
+  checkOut,
   catchType,
   originalPrice,
   discountRate,
@@ -52,16 +54,28 @@ const CatchSpecialComponent = ({
     console.log('삭제버튼이 클릭됐습니다.');
   },
 }: catchItems) => {
+  const checkInString = formatDateWithDay(checkIn!);
+  const checkOutString = formatDateWithDay(checkOut!);
+
   const deleteHandler = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     deleteBtnHandler();
   };
 
+  // 반응형 작업중입니다! 지우지 말아주세요~
+  // const truncateString = (str: string) => {
+  //   if (str.length > 10) {
+  //     return str.substring(0, 10) + '...';
+  //   } else {
+  //     return str;
+  //   }
+  // };
+
   return (
     <div className="relative w-full h-36">
       <div className="flex cursor-pointer" onClick={pageHandler}>
         {/* 숙소 이미지 및 캐치특가 */}
-        <div className="relative w-[120px] max-w-[120px] overflow-auto rounded-md mr-4">
+        <div className="relative flex w-[120px] max-w-[120px] overflow-hidden rounded-md mr-4">
           {catchType ? (
             <div className="absolute flex items-center z-[4] px-2 ml-2 mt-2 rounded-full bg-main text-p2 text-white font-medium">
               캐치 특가
@@ -77,26 +91,26 @@ const CatchSpecialComponent = ({
           <div className="mb-3 ">
             <div className="flex items-center gap-1 text-t3 font-semibold">
               <CalendarIcon />
-              {resDate}
+              {checkInString} - {checkOutString}
             </div>
-            <div className="flex flex-col items-start mt-3 gap-3">
-              <div className="text-t1 font-bold leading-none">
+            <div className=" flex flex-col items-start mt-3 gap-3 ">
+              <div className="text-t1 font-bold leading-none truncate overflow-ellipsis">
                 {accommodationName}
               </div>
-              <div className="text-t1 font-bold leading-none text-text-sub">
-                {roomName}
+              <div className="text-t1 font-bold leading-none text-text-sub break-keep overflow-ellipsis">
+                {roomName!}
               </div>
             </div>
           </div>
-          <div className="flex flex-col items-start">
+          <div className="flex flex-col items-start lg:items-end ">
             <div className="flex flex-wrap text-p2 text-gray-600">
               <p className="line-through">
                 구매가&nbsp;{originalPrice?.toLocaleString('us-EN')}원
               </p>
             </div>
             <div className="flex flex-wrap items-center">
-              <p className="text-t1 text-main font-bold">{discountRate}%</p>
-              <p className=" text-t1 font-bold ml-2">
+              <p className="text-t1 text-main font-semibold">{discountRate}%</p>
+              <p className=" text-t1 font-bold ml-2 lg:text-h5">
                 {sellPrice?.toLocaleString('us-EN')}원
               </p>
             </div>

--- a/components/common/checkInDateComponent/index.tsx
+++ b/components/common/checkInDateComponent/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { CheckInComponentProps } from '@/types/common/checkInComponent/types';
 import { CHECKIN_TIME, CHECKOUT_TIME } from '@/constants/CheckInOut';
+import { formatDateWithDay } from '@/utils/get-dot-date';
 /**
  * 개별 상품의 체크인-체크아웃 날짜를 확인할 수 있는 컴포넌트입니다.
  * props로 checkInDate, CheckInTime, CheckOutDate, CheckOutTime 네가지를 입력받아야 합니다.
@@ -14,19 +15,21 @@ const CheckInDateComponent = ({
   CheckInDate = '00.00 (월)',
   CheckOutDate = '00.00 (월)',
 }: CheckInComponentProps) => {
+  const checkInString = formatDateWithDay(CheckInDate);
+  const checkOutString = formatDateWithDay(CheckOutDate);
   return (
     <div className="relative flex flex-wrap w-full h-[5.625rem] mt-2 items-center justify-around bg-surface-gray rounded-[4px]">
       <div className="text-center">
         <div className="text-t3 font-medium text-gray-600">체크인</div>
         <div className="text-p1 font-semibold text-gray-800">
-          {CheckInDate} {CHECKIN_TIME}
+          {checkInString} {CHECKIN_TIME}
         </div>
       </div>
       <div className="absolute h-[37px] w-[1px] bg-gray-400 top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2" />
       <div className="text-center">
         <div className="text-t3 font-medium text-gray-600">체크아웃</div>
         <div className="text-p1 font-semibold text-gray-800">
-          {CheckOutDate} {CHECKOUT_TIME}
+          {checkOutString} {CHECKOUT_TIME}
         </div>
       </div>
     </div>

--- a/components/common/checkInDateComponent/index.tsx
+++ b/components/common/checkInDateComponent/index.tsx
@@ -17,14 +17,14 @@ const CheckInDateComponent = ({
   return (
     <div className="relative flex flex-wrap w-full h-[5.625rem] mt-2 items-center justify-around bg-surface-gray rounded-[4px]">
       <div className="text-center">
-        <div className="text-p1 font-medium text-gray-600">체크인</div>
+        <div className="text-t3 font-medium text-gray-600">체크인</div>
         <div className="text-p1 font-semibold text-gray-800">
           {CheckInDate} {CHECKIN_TIME}
         </div>
       </div>
       <div className="absolute h-[37px] w-[1px] bg-gray-400 top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2" />
       <div className="text-center">
-        <div className="text-p1 font-medium text-gray-600">체크아웃</div>
+        <div className="text-t3 font-medium text-gray-600">체크아웃</div>
         <div className="text-p1 font-semibold text-gray-800">
           {CheckOutDate} {CHECKOUT_TIME}
         </div>

--- a/components/common/searchBoxButton/index.tsx
+++ b/components/common/searchBoxButton/index.tsx
@@ -30,7 +30,7 @@ const SearchBoxButton = ({
         {icon === 'calendar' && <CalendarIcon />}
         {icon === 'house' && <HouseIcon />}
         {icon === 'person' && <PersonIcon />}
-        <p className="ml-2">{placeholder}</p>
+        <p className="ml-2 text-p1">{placeholder}</p>
       </div>
       <DownArrowIcon />
     </button>

--- a/components/common/searchBtmSheets/calendar/index.tsx
+++ b/components/common/searchBtmSheets/calendar/index.tsx
@@ -82,7 +82,7 @@ const CalendarBottomSheet = ({
             closeButton
             innerButtonTitle={'확인'}
           >
-            <div className="my-5 pb-2 w-full">
+            <div className="my-6 pb-2 w-full">
               {prop.icon === 'calendar' && (
                 <>
                   <CheckBoxComponent

--- a/components/common/searchBtmSheets/customer/index.tsx
+++ b/components/common/searchBtmSheets/customer/index.tsx
@@ -54,7 +54,7 @@ const CustomerBottomSheet = ({
             closeButton
             innerButtonTitle={'확인'}
           >
-            <div className="my-5 w-full">
+            <div className="my-6 w-full">
               {prop.icon === 'person' && (
                 <div className="flex flex-col justify-between w-full h-[7rem] p-auto bg-white border border-border-sub rounded-md p-5">
                   <div className="flex flex-row justify-between">

--- a/components/common/searchBtmSheets/region/index.tsx
+++ b/components/common/searchBtmSheets/region/index.tsx
@@ -120,7 +120,7 @@ const RegionBottomSheet = ({
             closeButton
             innerButtonTitle={'확인'}
           >
-            <div className="my-5 w-full">
+            <div className="my-6 w-full">
               {prop.icon === 'pin' && (
                 <>
                   <CheckBoxComponent

--- a/components/common/searchBtmSheets/room/index.tsx
+++ b/components/common/searchBtmSheets/room/index.tsx
@@ -96,7 +96,7 @@ const RoomBottomSheet = ({
             closeButton
             innerButtonTitle={'확인'}
           >
-            <div className="my-5 w-full">
+            <div className="my-6 w-full">
               {prop.icon === 'house' && (
                 <>
                   <CheckBoxComponent

--- a/components/home/checkIn/index.tsx
+++ b/components/home/checkIn/index.tsx
@@ -30,14 +30,14 @@ const CheckInComponent = () => {
       <div className="text-h4 font-extrabold">
         <p>체크인 마감임박!</p>
       </div>
-      <div className="relative w-full h-[34.375rem] rounded-lg border-2 border-border-sub bg-white pt-5 px-5 mt-3 mx-auto">
+      <div className="relative w-full h-[34.375rem] rounded-lg border-[1px] border-border-sub bg-white pt-5 px-5 mt-3 mx-auto">
         {/* 상단 일주일 달력 */}
         <div className="flex flex-wrap items-center justify-between h-[4rem] mb-[1.75rem] text-p1 font-semibold">
           <WeekCalendar />
         </div>
 
         {/* 캐치특가 상품 목록 */}
-        <div className="w-full h-[434px] flex flex-col justify-start gap-9 overflow-hidden">
+        <div className="w-full h-[436px] flex flex-col justify-start gap-[2rem] overflow-hidden">
           {data &&
             data.list.map((data: DeadLineItem) => {
               return (
@@ -46,7 +46,8 @@ const CheckInComponent = () => {
                   image={data.image}
                   accommodationName={data.accommodationName}
                   roomName={data.roomName}
-                  resDate={data.checkIn + ' - ' + data.checkOut}
+                  checkIn={data.checkIn}
+                  checkOut={data.checkOut}
                   catchType={data.catchType}
                   originalPrice={data.originalPrice}
                   sellPrice={data.sellPrice}
@@ -64,7 +65,7 @@ const CheckInComponent = () => {
         </div>
 
         {/* 전체보기 버튼 컴포넌트 */}
-        <div className="relative bottom-16 w-full z-20 bg-white rounded-[4px]">
+        <div className="relative bottom-20 w-full z-20 bg-white rounded-[4px]">
           <Button
             placeholder="button"
             loading={isBtnLoading ? true : false}
@@ -74,7 +75,7 @@ const CheckInComponent = () => {
             {isBtnLoading ? '' : '전체보기'}
           </Button>
         </div>
-        <div className="absolute inset-x-0 bottom-0 h-[130px] rounded-lg bg-gradient-to-t from-[#ffffffbd] to-transparent" />
+        <div className="absolute inset-x-0 bottom-0 z-10 h-[130px] rounded-lg bg-gradient-to-t from-[#ffffffbd] to-transparent" />
       </div>
     </div>
   );

--- a/components/roomInfo/body/navbarSection/navbarButton/index.tsx
+++ b/components/roomInfo/body/navbarSection/navbarButton/index.tsx
@@ -1,11 +1,16 @@
 'use client';
-import React from 'react';
-import { useRecoilState } from 'recoil';
+import React, { useEffect } from 'react';
+import { useRecoilState, useResetRecoilState } from 'recoil';
 import { activeButtonState } from '@/atoms/roomInfo/navbarButton';
 import { ButtonType } from '@/types/room-info/types';
 
 const NavbarButtonComponent = () => {
   const [activeButton, setActiveButton] = useRecoilState(activeButtonState);
+  const resetNavBtnState = useResetRecoilState(activeButtonState);
+
+  useEffect(() => {
+    resetNavBtnState(); // eslint-disable-next-line
+  }, []);
 
   const relativeStyle = 'relative flex w-1/3 h-[34px]';
   const absoluteStyle =

--- a/components/roomInfo/body/navbarSection/page/accInfo/index.tsx
+++ b/components/roomInfo/body/navbarSection/page/accInfo/index.tsx
@@ -1,13 +1,40 @@
+'use client';
+import { useRoomItem } from '@/api/room-info/query';
+import PinkCheckIcon from '@/public/svgComponent/roomInfo/navbarSection/pinkCheckIcon';
+import { UseParamsType } from '@/types/room-info/types';
+import { useParams } from 'next/navigation';
 import React from 'react';
 
 const NavAccInfoComponent = () => {
-  // 필요한 데이터
-  // (편의시설 관련 정보)
+  const { id } = useParams() as UseParamsType;
+  const { data, isLoading } = useRoomItem(id);
+
   return (
     <div className="w-full h-[235px] ">
-      <div className="flex flex-col w-full h-full items-center justify-center text-p2 bg-gray-300">
-        내용
-      </div>
+      {isLoading ? (
+        <>
+          <div className="flex flex-col w-full h-full items-center justify-center text-p2 bg-gray-400 animate-pulse" />
+        </>
+      ) : (
+        <>
+          <p className="text-t1 font-bold mb-3">시설 및 서비스</p>
+          <div className="grid grid-cols-2">
+            {data?.data.accommodationService.map(
+              (data: string[], index: number) => {
+                return (
+                  <p
+                    key={index}
+                    className="flex gap-2 items-center text-t3 mb-2 font-normal"
+                  >
+                    <PinkCheckIcon />
+                    {data}
+                  </p>
+                );
+              },
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 };

--- a/components/roomInfo/body/navbarSection/page/accRegion/index.tsx
+++ b/components/roomInfo/body/navbarSection/page/accRegion/index.tsx
@@ -11,7 +11,7 @@ const NavAccRegionComponent = () => {
   const { id } = useParams() as UseParamsType;
   const { data } = useRoomItem(id);
 
-  const address = data && data.data.address;
+  const address = data?.data.address;
 
   const { alertOpenHandler } = useToastAlert('주소를 복사했어요!');
 

--- a/components/roomInfo/body/navbarSection/page/roomInfo/index.tsx
+++ b/components/roomInfo/body/navbarSection/page/roomInfo/index.tsx
@@ -20,7 +20,7 @@ const NavRoomInfoComponent = () => {
           </>
         ) : (
           <>
-            {data && data.data.roomUrl && (
+            {data?.data.roomUrl && (
               <Image
                 src={data.data.roomUrl[0].url}
                 layout="fill"
@@ -42,8 +42,8 @@ const NavRoomInfoComponent = () => {
         <div>
           <p className="flex items-center gap-1 text-p3 text-text-sub leading-5">
             <SmPersonIcon />
-            기준 {data && data.data.roomNormalCapacity}인 / 최대
-            {data && data.data.roomMaxCapacity}
+            기준 {data?.data.roomNormalCapacity}인 / 최대{' '}
+            {data?.data.roomMaxCapacity}인
           </p>
           <p className="flex items-center gap-1 text-p3 text-text-sub">
             <SmBedIcon />퀸 침대

--- a/components/roomInfo/body/roomInfo/itemCheckIn/index.tsx
+++ b/components/roomInfo/body/roomInfo/itemCheckIn/index.tsx
@@ -2,7 +2,6 @@
 import { useRoomItem } from '@/api/room-info/query';
 import CheckInDateComponent from '@/components/common/checkInDateComponent';
 import { UseParamsType } from '@/types/room-info/types';
-import { formatDateWithDay } from '@/utils/get-dot-date';
 import { useParams } from 'next/navigation';
 import React from 'react';
 
@@ -10,16 +9,14 @@ const ItemCheckInComponent = () => {
   const { id } = useParams() as UseParamsType;
   const { data, isLoading } = useRoomItem(id);
 
-  const checkInString = formatDateWithDay(data?.data.checkIn);
-  const checkOutString = formatDateWithDay(data?.data.checkOut);
   return (
     <>
       {isLoading ? (
         <div className="relative flex flex-wrap w-full h-[5.625rem] mt-2 items-center justify-around bg-gray-400 rounded-[4px] animate-pulse"></div>
       ) : (
         <CheckInDateComponent
-          CheckInDate={checkInString}
-          CheckOutDate={checkOutString}
+          CheckInDate={data?.data.checkIn}
+          CheckOutDate={data?.data.checkOut}
         />
       )}
     </>

--- a/components/roomInfo/body/roomInfo/itemCheckIn/index.tsx
+++ b/components/roomInfo/body/roomInfo/itemCheckIn/index.tsx
@@ -2,7 +2,7 @@
 import { useRoomItem } from '@/api/room-info/query';
 import CheckInDateComponent from '@/components/common/checkInDateComponent';
 import { UseParamsType } from '@/types/room-info/types';
-import { getDotDate } from '@/utils/get-dot-date';
+import { formatDateWithDay } from '@/utils/get-dot-date';
 import { useParams } from 'next/navigation';
 import React from 'react';
 
@@ -10,18 +10,16 @@ const ItemCheckInComponent = () => {
   const { id } = useParams() as UseParamsType;
   const { data, isLoading } = useRoomItem(id);
 
+  const checkInString = formatDateWithDay(data?.data.checkIn);
+  const checkOutString = formatDateWithDay(data?.data.checkOut);
   return (
     <>
       {isLoading ? (
         <div className="relative flex flex-wrap w-full h-[5.625rem] mt-2 items-center justify-around bg-gray-400 rounded-[4px] animate-pulse"></div>
       ) : (
         <CheckInDateComponent
-          CheckInDate={getDotDate(`${data && data.data.checkIn}`, false, false)}
-          CheckOutDate={getDotDate(
-            `${data && data.data.checkOut}`,
-            false,
-            true,
-          )}
+          CheckInDate={checkInString}
+          CheckOutDate={checkOutString}
         />
       )}
     </>

--- a/components/roomInfo/body/roomInfo/price/index.tsx
+++ b/components/roomInfo/body/roomInfo/price/index.tsx
@@ -19,12 +19,9 @@ const PriceComponent = () => {
           </>
         ) : (
           <>
-            <span className="text-t2 font-semibold">구매가</span>
+            <span className="text-t2 font-normal">구매가</span>
             <p className="text-t2 text-gray-600  font-semibold">
-              {data &&
-                data.data.originalPrice &&
-                data.data.originalPrice.toLocaleString()}
-              원
+              {data?.data.originalPrice?.toLocaleString()}원
             </p>
           </>
         )}
@@ -38,16 +35,13 @@ const PriceComponent = () => {
           </>
         ) : (
           <>
-            <span className="text-t2 font-semibold">판매가</span>
+            <span className="text-t2 font-normal">판매가</span>
             <div className="flex flex-wrap items-center justify-center">
               <p className=" text-main font-bold">
                 {data && data.data.discountRate}%
               </p>
               <p className="ml-2 text-h4 font-bold">
-                {data &&
-                  data.data.sellPrice &&
-                  data.data.sellPrice.toLocaleString()}
-                원
+                {data?.data.sellPrice?.toLocaleString()}원
               </p>
             </div>
           </>

--- a/components/roomInfo/footer/index.tsx
+++ b/components/roomInfo/footer/index.tsx
@@ -2,6 +2,9 @@
 
 import React from 'react';
 import { Button } from '@material-tailwind/react';
+// import { UseParamsType } from '@/types/room-info/types';
+// import { useParams } from 'next/navigation';
+// import { useRoomItem } from '@/api/room-info/query';
 import { useRecoilState } from 'recoil';
 import { viewerTestButton } from '@/atoms/roomInfo/headerTitle';
 
@@ -12,8 +15,9 @@ const FooterComponent = () => {
   const [viewerState] = useRecoilState(viewerTestButton);
 
   // 지민님 작업 끝나시면 이어서 할 예정.
-  // const { id } = useParams();
+  // const { id } = useParams() as UseParamsType;
   // const { data } = useRoomItem(id);
+  // const userState = data?.data.userIdentity;
 
   const buttonClass =
     'font-pretend h-full rounded-[4px] text-t1 font-semibold shadow-none';

--- a/components/searchroom/bodyComponent/searchComponent/userCounter/index.tsx
+++ b/components/searchroom/bodyComponent/searchComponent/userCounter/index.tsx
@@ -20,18 +20,13 @@ const UserCounterComponent = ({ countState, allCount }: UserCounterProps) => {
   );
 
   useEffect(() => {
-    if (count === 1) {
+    if ((countState === 'adult' && count === 1) || count === 0)
       setMBtnState(false);
-    } else {
-      setMBtnState(true);
-    }
+    else setMBtnState(true);
 
-    if (count === 10 || allCount === 10) {
-      setPBtnState(false);
-    } else {
-      setPBtnState(true);
-    }
-  }, [count, allCount]);
+    if (count === 10 || allCount === 10) setPBtnState(false);
+    else setPBtnState(true);
+  }, [count, allCount, countState]);
 
   const onDecrease = () => {
     setCount((prev) => prev - 1);
@@ -42,7 +37,18 @@ const UserCounterComponent = ({ countState, allCount }: UserCounterProps) => {
 
   return (
     <div className="relative flex justify-between w-[80px]">
-      <button onClick={onDecrease} disabled={count === 1 ? true : false}>
+      <button
+        onClick={onDecrease}
+        disabled={
+          countState === 'adult'
+            ? count === 1
+              ? true
+              : false
+            : count === 0
+              ? true
+              : false
+        }
+      >
         <MinusBtnIcon isActive={mBtnState} />
       </button>
       <p className="absolute left-1/2 transform -translate-x-1/2">{count}</p>

--- a/public/svgComponent/roomInfo/navbarSection/pinkCheckIcon.tsx
+++ b/public/svgComponent/roomInfo/navbarSection/pinkCheckIcon.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+const PinkCheckIcon = () => (
+  <svg
+    width={16}
+    height={16}
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M3 8.5L6.5 12L13.5 5"
+      stroke="#FF3478"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+export default PinkCheckIcon;


### PR DESCRIPTION
## ✨ 이슈번호
none

## ☎ 추가 전달 사항
### 1. 숙소별 상세정보 받아옵니다. (랜덤하게 오더라구요)
![image](https://github.com/catchroom/FE_CatchRoom/assets/122848687/3c698c1a-1fec-4847-aba2-9baccca2ff35)

### 2. 상품 공동 컴포넌트 체크 인 & 아웃 props 변경
![image](https://github.com/catchroom/FE_CatchRoom/assets/122848687/9243ae1e-a086-4355-a689-ed892b5c1e41)

현재 PR Pull 하시면 위처럼 날짜부분 오류가 뜰겁니다

![image](https://github.com/catchroom/FE_CatchRoom/assets/122848687/6b8fa512-d373-447a-bb6d-94bfeeb877f9)

기존에 사용하시던 `resDate` 부분은 이제 

`checkIn`, `CheckOut`으로 세분화됩니다.

![image](https://github.com/catchroom/FE_CatchRoom/assets/122848687/472ab0de-d6e6-4403-92a7-05c9fc45f65e)

api로 받아오신 `2024-00-00` string 데이터 바로 집어넣으시면 됩니다!

![image](https://github.com/catchroom/FE_CatchRoom/assets/122848687/ff8c7741-2757-423d-be80-582cdaec502e)

@suyeonnnnnnn  수연님 여기도 똑같이 적용되어 있어요 한번 확인 부탁드려요
